### PR TITLE
Enable/disable commands

### DIFF
--- a/src/main/java/me/fallenbreath/velocitywhitelist/WhitelistManager.java
+++ b/src/main/java/me/fallenbreath/velocitywhitelist/WhitelistManager.java
@@ -35,8 +35,8 @@ public class WhitelistManager
 	{
 		this.logger = logger;
 		this.config = config;
-		this.whitelist = new PlayerList("Whitelist", dataDirectory.resolve("whitelist.yml"), this.config::isWhitelistEnabled);
-		this.blacklist = new PlayerList("Blacklist", dataDirectory.resolve("blacklist.yml"), this.config::isBlacklistEnabled);
+		this.whitelist = new PlayerList("Whitelist", dataDirectory.resolve("whitelist.yml"));
+		this.blacklist = new PlayerList("Blacklist", dataDirectory.resolve("blacklist.yml"));
 		this.server = server;
 	}
 
@@ -54,6 +54,12 @@ public class WhitelistManager
 	{
 		this.loadOneList(this.whitelist);
 		this.loadOneList(this.blacklist);
+	}
+
+	public void enableList(PlayerList list, boolean enabled)
+	{
+		list.setEnabled(enabled);
+		saveList(list);
 	}
 
 	private boolean isPlayerInList(GameProfile profile, PlayerList list)

--- a/src/main/java/me/fallenbreath/velocitywhitelist/WhitelistManager.java
+++ b/src/main/java/me/fallenbreath/velocitywhitelist/WhitelistManager.java
@@ -35,8 +35,8 @@ public class WhitelistManager
 	{
 		this.logger = logger;
 		this.config = config;
-		this.whitelist = new PlayerList("Whitelist", dataDirectory.resolve("whitelist.yml"));
-		this.blacklist = new PlayerList("Blacklist", dataDirectory.resolve("blacklist.yml"));
+		this.whitelist = new PlayerList("Whitelist", dataDirectory.resolve("whitelist.yml"), config::getMigrateWhitelistEnabled);
+		this.blacklist = new PlayerList("Blacklist", dataDirectory.resolve("blacklist.yml"), config::getMigrateBlacklistEnabled);
 		this.server = server;
 	}
 

--- a/src/main/java/me/fallenbreath/velocitywhitelist/config/Configuration.java
+++ b/src/main/java/me/fallenbreath/velocitywhitelist/config/Configuration.java
@@ -55,9 +55,7 @@ public class Configuration
 			Map<String, Object> newOptions = Maps.newLinkedHashMap();
 			newOptions.put("_version", 1);
 			newOptions.put("identify_mode", Optional.ofNullable(this.options.get("identify_mode")).orElse("name"));
-			newOptions.put("whitelist_enabled", Optional.ofNullable(this.options.get("enabled")).orElse(true));
 			newOptions.put("whitelist_kick_message", Optional.ofNullable(this.options.get("kick_message")).orElse("You are not in the whitelist!"));
-			newOptions.put("blacklist_enabled", Optional.ofNullable(this.options.get("enabled")).orElse(true));  // it's ok to enable an empty blacklist
 			newOptions.put("blacklist_kick_message", "You are banned from the server!");
 
 			this.options.clear();
@@ -98,26 +96,6 @@ public class Configuration
 			}
 		}
 		return IdentifyMode.DEFAULT;
-	}
-
-	public boolean isWhitelistEnabled()
-	{
-		Object enabled = this.options.get("whitelist_enabled");
-		if (enabled instanceof Boolean)
-		{
-			return (Boolean)enabled;
-		}
-		return false;
-	}
-
-	public boolean isBlacklistEnabled()
-	{
-		Object enabled = this.options.get("blacklist_enabled");
-		if (enabled instanceof Boolean)
-		{
-			return (Boolean)enabled;
-		}
-		return false;
 	}
 
 	public IdentifyMode getIdentifyMode()

--- a/src/main/java/me/fallenbreath/velocitywhitelist/config/Configuration.java
+++ b/src/main/java/me/fallenbreath/velocitywhitelist/config/Configuration.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import me.fallenbreath.velocitywhitelist.IdentifyMode;
 import me.fallenbreath.velocitywhitelist.PluginMeta;
 import me.fallenbreath.velocitywhitelist.utils.FileUtils;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.yaml.snakeyaml.Yaml;
 
@@ -20,6 +21,9 @@ public class Configuration
 	private final Path configFilePath;
 
 	private IdentifyMode identifyMode = IdentifyMode.DEFAULT;
+
+    private Boolean migrateWhitelistEnabled;
+    private Boolean migrateBlacklistEnabled;
 
 	public Configuration(Logger logger, Path configFilePath)
 	{
@@ -62,6 +66,27 @@ public class Configuration
 			this.options.putAll(newOptions);
 			migrated = true;
 		}
+        if (this.options.get("_version") instanceof  Integer version) {
+            if (version == 1) {
+                // migrate config version 1 to 2
+
+                Object whitelistEnabled = this.options.get("whitelist_enabled");
+                if (whitelistEnabled instanceof Boolean boolWhitelistEnabled) {
+                    this.migrateWhitelistEnabled = boolWhitelistEnabled;
+                }
+                this.options.remove("whitelist_enabled");
+                Object blacklistEnabled = this.options.get("blacklist_enabled");
+                if (blacklistEnabled instanceof Boolean boolBlacklistEnabled) {
+                    this.migrateBlacklistEnabled = boolBlacklistEnabled;
+                }
+                this.options.remove("blacklist_enabled");
+
+                this.options.remove("_version");
+                this.options.put("_version", 2);
+
+                migrated = true;
+            }
+        }
 
 		if (migrated)
 		{
@@ -102,6 +127,16 @@ public class Configuration
 	{
 		return this.identifyMode;
 	}
+
+    public @Nullable Boolean getMigrateWhitelistEnabled()
+    {
+        return this.migrateWhitelistEnabled;
+    }
+
+    public @Nullable Boolean getMigrateBlacklistEnabled()
+    {
+        return this.migrateBlacklistEnabled;
+    }
 
 	public String getWhitelistKickMessage()
 	{

--- a/src/main/java/me/fallenbreath/velocitywhitelist/config/PlayerList.java
+++ b/src/main/java/me/fallenbreath/velocitywhitelist/config/PlayerList.java
@@ -23,7 +23,6 @@ import java.util.UUID;
 
 public class PlayerList
 {
-    private static final Logger log = LoggerFactory.getLogger(PlayerList.class);
     private final Set<String> names = Sets.newLinkedHashSet();
 	private final Map<UUID, @Nullable String> uuids = Maps.newLinkedHashMap();
 	private final String name;

--- a/src/main/java/me/fallenbreath/velocitywhitelist/config/PlayerList.java
+++ b/src/main/java/me/fallenbreath/velocitywhitelist/config/PlayerList.java
@@ -10,6 +10,7 @@ import me.fallenbreath.velocitywhitelist.utils.UuidUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
@@ -22,18 +23,21 @@ import java.util.UUID;
 
 public class PlayerList
 {
-	private final Set<String> names = Sets.newLinkedHashSet();
+    private static final Logger log = LoggerFactory.getLogger(PlayerList.class);
+    private final Set<String> names = Sets.newLinkedHashSet();
 	private final Map<UUID, @Nullable String> uuids = Maps.newLinkedHashMap();
 	private final String name;
 	private final Path filePath;
+    private final Supplier<Boolean> migrateConfigEnable;
 	private boolean loadOk = false;
 	private final Object lock = new Object();
 	private boolean enabled;
 
-	public PlayerList(String name, Path filePath)
+	public PlayerList(String name, Path filePath, Supplier<Boolean> migrateConfigEnable)
 	{
 		this.name = name;
 		this.filePath = filePath;
+        this.migrateConfigEnable = migrateConfigEnable;
 	}
 
 	public String getName()
@@ -181,13 +185,14 @@ public class PlayerList
 			this.names.addAll(newList.names);
 			this.uuids.clear();
 			this.uuids.putAll(newList.uuids);
+            this.enabled = newList.enabled;
 			this.loadOk = true;
 		}
 	}
 
 	public PlayerList createNewEmptyList()
 	{
-		return new PlayerList(this.name, this.filePath);
+		return new PlayerList(this.name, this.filePath, migrateConfigEnable);
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
@@ -200,11 +205,18 @@ public class PlayerList
 
 		synchronized (this.lock)
 		{
-			if (options.get("enabled") instanceof Boolean bool) {
-				this.enabled = bool;
-			} else {
-				this.enabled = false;
-			}
+            Boolean migrateValue = migrateConfigEnable.get();
+            if (migrateValue != null) {
+                logger.info("List {} migrated enable value from configuration.", getName());
+                setEnabled(migrateValue);
+                save();
+            } else {
+                if (options.get("enabled") instanceof Boolean bool) {
+                    setEnabled(bool);
+                } else {
+                    setEnabled(false);
+                }
+            }
 
 			this.names.clear();
 			if (options.get("names") instanceof List list)
@@ -251,7 +263,7 @@ public class PlayerList
 
 			this.loadOk = true;
 			logger.info("{} loaded with {} names and {} uuids", this.name, this.names.size(), this.uuids.size());
-		}
+        }
 	}
 
 	public void save() throws IOException

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,12 +7,8 @@ _version: 1
 # since it can keep tracking on the mojang account of the player
 identify_mode: name
 
-# If the whitelist functionality is enabled
-whitelist_enabled: true
 # Message sent to those not whitelisted players
 whitelist_kick_message: You are not in the whitelist!
 
-# If the blacklist functionality is enabled
-blacklist_enabled: true
 # Message sent to those blacklisted players
 blacklist_kick_message: You are banned from the server!

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 # Config file version. Do not edit it
-_version: 1
+_version: 2
 
 # The way to identify a player
 # Options: name, uuid. Default: name


### PR DESCRIPTION
Adds the ability to enable and disable a list via command.

These commands have been added:
```
/whitelist enable - enable the whitelist
/whitelist disable - disable the whitelist
/blacklist enable - enable the blacklist
/blacklist disable - disable the blacklist
```
Also added the 'enabled' option in the list configurations (whitelist.yml and blacklist.yml) and removed 'whitelist_enabled' and 'blacklist_enabled' from the main configuration.
